### PR TITLE
feat: add get_crowdfundings method and corresponding tests

### DIFF
--- a/src/crowdfundingFactory.cairo
+++ b/src/crowdfundingFactory.cairo
@@ -5,6 +5,7 @@ pub trait ICrowdfundingFactory<TContractState> {
   fn create_crowdfunding(ref self: TContractState, manager: ContractAddress, minimum_contribute: usize) -> ContractAddress;
   fn update_crowdfunding_class_hash(ref self: TContractState, new_class_hash: ClassHash);
   fn get_crowdfunding_class_hash(ref self: TContractState) -> ClassHash;
+  fn get_crowdfundings(ref self: TContractState) -> Array<ContractAddress>;
 }
 
 #[starknet::contract]
@@ -33,7 +34,7 @@ pub mod CrowdfundingFactory {
 
       let (deployed_address, _) = deploy_syscall(
         self.crowdfunding_class_hash.read(),
-        0,
+        self.crowdfundings.len().into(),
         constructor_calldata.span(),
         false,
       ).unwrap();
@@ -48,6 +49,16 @@ pub mod CrowdfundingFactory {
 
     fn get_crowdfunding_class_hash(ref self: ContractState) -> ClassHash {
       self.crowdfunding_class_hash.read()
+    }
+
+    fn get_crowdfundings(ref self: ContractState) -> Array<ContractAddress> {      
+      let mut crowdfundings = array![];
+
+      for i in 0..self.crowdfundings.len() {
+        crowdfundings.append(self.crowdfundings.at(i).read());
+      };
+
+      crowdfundings
     }
   }
 }

--- a/tests/crowdfundingFactoryTest.cairo
+++ b/tests/crowdfundingFactoryTest.cairo
@@ -39,3 +39,37 @@ fn it_should_update_crowdfunding_class_hash() {
 
   assert_eq!(crowdfunding_factory.get_crowdfunding_class_hash(), new_class_hash);
 }
+
+#[test]
+fn it_should_get_crowdfundings() {
+  let crowdfunding_class_hash = declare_crowdfunding_contract();
+  let (crowdfunding_factory, _) = deploy_crowdfunding_factory(crowdfunding_class_hash);
+
+  let caller = ADDRESSES::CALLER.get();
+  let minimum_contribution = 10;
+
+  let crowdfunding1 = crowdfunding_factory.create_crowdfunding(caller, minimum_contribution);
+  let crowdfunding2 = crowdfunding_factory.create_crowdfunding(caller, minimum_contribution);
+
+  let crowdfundings = crowdfunding_factory.get_crowdfundings();
+
+  assert_eq!(crowdfundings.len(), 2);
+
+  let mut is_crowdfunding1_contained_in_crowdfundings = false;
+  let mut is_crowdfunding2_contained_in_crowdfundings = false;
+  let mut number_of_crowdfundings = 2;
+  for address in crowdfundings {
+    if address == crowdfunding1 {
+      is_crowdfunding1_contained_in_crowdfundings = true;
+      number_of_crowdfundings -= 1;
+    } else if address == crowdfunding2 {
+      is_crowdfunding2_contained_in_crowdfundings = true;
+      number_of_crowdfundings -= 1;
+    } else if number_of_crowdfundings == 0 {
+      break;
+    }
+  };
+
+  assert!(is_crowdfunding1_contained_in_crowdfundings, "crowdfunding1 should be in the list of crowdfundings");
+  assert!(is_crowdfunding2_contained_in_crowdfundings, "crowdfunding2 should be in the list of crowdfundings");
+}


### PR DESCRIPTION
This pull request enhances the `CrowdfundingFactory` contract by adding functionality to retrieve all deployed crowdfunding contracts and includes corresponding test coverage. The most important changes introduce a new method for fetching crowdfunding addresses and modify the deployment logic to ensure proper indexing.

### Enhancements to `CrowdfundingFactory` functionality:

* **Added `get_crowdfundings` method:** A new function `get_crowdfundings` was added to the `ICrowdfundingFactory` trait and implemented in the `CrowdfundingFactory` module. This method retrieves all crowdfunding contract addresses stored within the factory. (`src/crowdfundingFactory.cairo`, [[1]](diffhunk://#diff-8d1fcc9375745083b65d3d5234983f953b6a5239151dad48c3de4d0999305857R8) [[2]](diffhunk://#diff-8d1fcc9375745083b65d3d5234983f953b6a5239151dad48c3de4d0999305857R53-R62)

* **Modified deployment logic:** The deployment syscall now uses the length of the `crowdfundings` array as part of the constructor calldata, ensuring proper indexing of deployed contracts. (`src/crowdfundingFactory.cairo`, [src/crowdfundingFactory.cairoL36-R37](diffhunk://#diff-8d1fcc9375745083b65d3d5234983f953b6a5239151dad48c3de4d0999305857L36-R37))

### Test coverage improvements:

* **Added test for `get_crowdfundings`:** A new test `it_should_get_crowdfundings` verifies that the `get_crowdfundings` method correctly retrieves all deployed crowdfunding contract addresses. The test ensures the list contains the correct number of contracts and validates their presence within the returned array. (`tests/crowdfundingFactoryTest.cairo`, [tests/crowdfundingFactoryTest.cairoR42-R75](diffhunk://#diff-2609704584c423aa261f8a1d1247d213a9ba3dcc85338acda1f7c538594e883bR42-R75))